### PR TITLE
Create installers via GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,32 @@
+name: Build application
+
+on:
+  push:
+    branches:
+      - "*"
+  pull_request:
+    branches:
+      - "*"
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.9"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Build Installers
+      run: |
+        python create_installer.py
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: installer
+        path: "installer/*.zip"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+*.pyc
+env
+venv
+dist
+build
+installer
+*.spec

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 build
 installer
 *.spec
+__pycache__

--- a/create_installer.py
+++ b/create_installer.py
@@ -1,0 +1,42 @@
+import os
+import subprocess
+import shutil
+
+def rm_dir(folder):
+    if os.path.exists(folder):
+        print(f"remove folder '{folder}'")
+        shutil.rmtree(folder)
+        print("remove succeeded")
+
+def make_installer(onefile=False, project_name="HSPR",installer_root_folder="installer"):
+    rm_dir("build")
+    rm_dir("dist")
+    cmd = ["pyinstaller", "--clean", "src/main.py", "-n", project_name]
+    if onefile:
+        cmd.append("--onefile")
+    subprocess.check_call(cmd)
+
+    input_folder = "dist"
+    if not onefile:
+        input_folder = os.path.join(input_folder, project_name)
+
+    output_filename = os.path.join(installer_root_folder, "hspr")
+    if onefile:
+        output_filename += "_onefile"
+
+    shutil.make_archive(output_filename, "zip", input_folder) # .zip extension will be attach by make_archive
+
+def main():
+    installer_folder = "installer"
+    rm_dir(installer_folder)
+    os.makedirs(installer_folder)
+
+    onefile = [True, False]
+    for o in onefile:
+        make_installer(
+            onefile=o,
+            installer_root_folder=installer_folder
+        )
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Hi 👋,

this PR build the installers via GitHub actions and store it, for now, as artifacts.

## Installers
I've add 2 installers.

- onefile

  As in previous versions

- multifile

  This version is much better in startup performance because the OS can cache it. The onefile installer always needs to unpack the file on every run which makes the startup really slow.

Both installers are simple `.zip` files.

Would be great when you can add [GitHub release](https://github.com/marketplace/actions/release-github-actions) for easy download for all the users.


Greetings
Michael