### PR TITLE
Hotfix qol

### DIFF
--- a/src/func/read_files.py
+++ b/src/func/read_files.py
@@ -1,6 +1,5 @@
 from os import read
 import numpy as np
-from main import MainWindow 
 from scipy.interpolate import interp2d
 
 import re
@@ -31,26 +30,40 @@ def read_ies_file(filetext):
         elif line == "TILT=INCLUDE": 
             raise Exception("The HSPR Software currently does not support TILT=INCLUDE please make sure light distribution is designed for TILT=NONE.")
     
-
-    # Check and process the line containing 10 values
+    idx_after10 = tilt_none_index + 2
     next_line = re.split(r'[,\s\r\n]+', lines[tilt_none_index + 1].strip())
-    if len(next_line) != 10:
-        raise Exception("The line following TILT=NONE must contain exactly 10 numerical values with the photometric specifications.")
+    if len(next_line) == 10: # IES file format as specified by the IESNA LM-63 standard
+        # Convert and assign the 10 photometric specifications
+        conversion_funcs = [int, float, float, int, int, int, int, float, float, float]
+        num_lamps, lumens_per_lamp, candela_multiplier, num_vert_angles, num_horiz_angles, photometric_type, units_type, width, length, height = [func(val) for func, val in zip(conversion_funcs, next_line)]
 
-    # Convert and assign the 10 photometric specifications
-    conversion_funcs = [int, float, float, int, int, int, int, float, float, float]
-
-    num_lamps, lumens_per_lamp, candela_multiplier, num_vert_angles, num_horiz_angles, photometric_type, units_type, width, length, height = [func(val) for func, val in zip(conversion_funcs, next_line)]
+    else: # non-standard IES file format but used by some manufacturers
+        # Read following 3 lines and check if the first is 4 values and the next two are 3 values each to get the 10 photometric specifications
+        second_line = re.split(r'[,\s\r\n]+', lines[tilt_none_index + 2].strip())
+        third_line = re.split(r'[,\s\r\n]+', lines[tilt_none_index + 3].strip())
+        
+        combined_values = next_line + second_line + third_line 
+        
+        if len(combined_values) != 10:
+            raise Exception("The photometric specifications are not formatted according to IESNA LM-63.The line after TILT=NONE must contain 10 values. Alternatively it is supported that the 10 photometric values can be split up in the three following lines.")
+        
+        # Combine the values from the three lines
+        combined_values = next_line + second_line + third_line
+        
+        # Convert and assign the 10 photometric specifications
+        conversion_funcs = [int, float, float, int, int, int, int, float, float, float]
+        num_lamps, lumens_per_lamp, candela_multiplier, num_vert_angles, num_horiz_angles, photometric_type, units_type, width, length, height = [func(val) for func, val in zip(conversion_funcs, combined_values)]
+        idx_after10 += 2
 
     # Check and process the line containing 3 values
-    next_line = re.split(r'[,\s\r\n]+', lines[tilt_none_index + 2].strip())
+    next_line = re.split(r'[,\s\r\n]+', lines[idx_after10].strip())
     if len(next_line) != 3:
-        raise Exception("The line following the 10-value line must contain exactly 3 numerical values.")
+        raise Exception("The line following the 10-value line must contain exactly 3 numerical values before the vertical angles. Check if the IES file is formatted according to IESNA LM-63.")
 
     # Convert and assign the next three values: ballast factor, file generation type, input watts
     ballast_factor, file_generation_type, input_watts = map(float, next_line)
 
-    remaining_data = "".join(lines[tilt_none_index + 3:])
+    remaining_data = "".join(lines[idx_after10 + 1:])
     new_iterator = iter(re.split(r'[,\s\r\n]+', remaining_data.strip()))
 
     vertical_angles = np.array([float(next(new_iterator)) for _ in range(num_vert_angles)])
@@ -58,7 +71,7 @@ def read_ies_file(filetext):
     candela_values = np.array([float(next(new_iterator)) for _ in range(num_vert_angles * num_horiz_angles)])
 
     if num_vert_angles*num_horiz_angles != len(candela_values):
-        raise ValueError(f"There is an error in the ies file. Please check if the file contains the prescribed quantity of photometric values and keywords.") 
+        raise ValueError(f"There is an error in the ies file. Please check if the file contains the prescribed quantity of photometric values and keywords in the correct format.") 
 
     candela_values = candela_values.reshape((num_horiz_angles, num_vert_angles)).T 
 

--- a/src/main.py
+++ b/src/main.py
@@ -425,6 +425,8 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         model = PandasModel(data)
         frame.setModel(model)
         self.align_table(frame)
+        self.checkbox_csv.setEnabled(True)
+        self.checkbox_xlsx.setEnabled(True)
 
     def closeEvent(self, event):
             event.accept()

--- a/src/settings/about.py
+++ b/src/settings/about.py
@@ -13,8 +13,8 @@ txt = '''
 This Application is used to assess the light distribution of various headlight systems. \n
 Please take the following steps to avoid any Errors: \n
 1) Upload the .ies files either in a single .zip folder containing the subfolders ADB, HB, and LB and the .ies files named according to the software manual.
-    Alternatively upload the files separately with the corresponding buttons. The second methode does not require specific file names. It is required that the line "TILT=NONE" of every IES file is followed by 13 numbers representing the lights parameters. \n
-2) Change the inputparameters to your car geometry. \n
+    Alternatively upload the files separately with the corresponding buttons. The second methode does not require specific file names. It is required that the line "TILT=NONE" exists in the file and it is formatted according to IESNA LM-63. \n
+2) Change the inputparameters to your car geometry or use default values. \n
 3) If you don't use an ADB system check manual or automatic. ADB systems are automatically selected. \n
 4) Start the computation by clicking on the Compute button. \n
 5) Wait until the progressbar is full and the results are displayed. \n


### PR DESCRIPTION
Changes to the file read so that it is possible to split the 10 photometric values after TILT=NONE to 3 or 4 lines. Does not matter how it is split up. This is not according to LM-63 anymore but will prevent a couple of support requests.